### PR TITLE
Removing import WarmupLinearSchedule

### DIFF
--- a/cbert_finetune.py
+++ b/cbert_finetune.py
@@ -14,7 +14,7 @@ import numpy as np
 import torch
 from torch.utils.data import TensorDataset, DataLoader, RandomSampler, SequentialSampler
 
-from transformers import BertTokenizer, BertModel, BertForMaskedLM, AdamW, WarmupLinearSchedule
+from transformers import BertTokenizer, BertModel, BertForMaskedLM, AdamW
 #import train_text_classifier_new
 
 import cbert_utils


### PR DESCRIPTION
Not supported by latest transformers library. See issue - https://github.com/huggingface/transformers/issues/2082
If warmup is required, we can instead use 
`scheduler = get_linear_schedule_with_warmup(optimizer, num_warmup_steps=WARMUP_STEPS, num_training_steps = -1)`
instead of `scheduler = WarmupLinearSchedule(optimizer, warmup_steps=WARMUP_STEPS, t_total = -1)`